### PR TITLE
util: better error handling

### DIFF
--- a/lastfm/util.go
+++ b/lastfm/util.go
@@ -242,6 +242,10 @@ func callGet(apiMethod string, params *apiParams, args map[string]interface{}, r
 	if err != nil {
 		return
 	}
+	if res.StatusCode/100 == 5 { // only 5xx class errors
+		err = newLibError(res.StatusCode, res.Status)
+		return
+	}
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return


### PR DESCRIPTION
last.fm sometimes responds with HTTP 500, 503, or other error codes. Reasons for this range from irregular varnish cache errors to broken software.

When lastfm-go gets such a result, it tries to parse them as xml, which results in an error `expected <lfm>, got <html>`.

This patch fixes that error by checking for HTTP 5xx error codes and directly returning them as an error.
