### PR TITLE
Removing api method-name as GET url param from POST requests.

### DIFF
--- a/lastfm/util.go
+++ b/lastfm/util.go
@@ -263,7 +263,6 @@ func callPost(apiMethod string, params *apiParams, args P, result interface{}, r
 	}
 
 	urlParams := url.Values{}
-	urlParams.Add("method", apiMethod)
 	uri := constructUrl(UriApiSecBase, urlParams)
 
 	//post data
@@ -311,7 +310,6 @@ func callPost(apiMethod string, params *apiParams, args P, result interface{}, r
 
 func callPostWithoutSession(apiMethod string, params *apiParams, args P, result interface{}, rules P) (err error) {
 	urlParams := url.Values{}
-	urlParams.Add("method", apiMethod)
 	uri := constructUrl(UriApiSecBase, urlParams)
 
 	//post data


### PR DESCRIPTION
Since the Last.fm relaunch all POST methods having the API method-name added too as GET param will fail with "Error 13: Invalid method signature supplied".

Removing "method" as GET-param in POST requests fixes this particular problem after relaunch.